### PR TITLE
fix: measure terminal columns in cells so CJK text lands correctly

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import readline from "node:readline";
 import { sanitizeTerminalText, wrapText } from "./format";
 import { stateDir } from "./paths";
+import { layoutComment } from "./layout";
+import { charWidth, stringWidth, truncateToWidth } from "./width";
 import type { StoreResult } from "./store";
 import {
   parsePendingAnnotation,
@@ -51,43 +53,21 @@ function moveCursorVertical(delta: number): void {
   const before = comment.slice(0, cursor).join("");
   const lines = before.split("\n");
   const row = lines.length - 1;
-  const col = Array.from(lines[row] ?? "").length;
+  const col = stringWidth(lines[row] ?? "");
   const allLines = comment.join("").split("\n");
   const targetRow = Math.max(0, Math.min(allLines.length - 1, row + delta));
   let next = 0;
-  for (let index = 0; index < targetRow; index += 1) next += Array.from(allLines[index]).length + 1;
-  cursor = next + Math.min(col, Array.from(allLines[targetRow]).length);
-}
-
-function commentLines(width: number): { lines: string[]; cursorRow: number; cursorCol: number } {
-  const safeWidth = Math.max(1, width);
-  const lines: string[] = [""];
-  let row = 0;
-  let col = 0;
-  let cursorRow = 0;
-  let cursorCol = 0;
-  for (let index = 0; index <= comment.length; index += 1) {
-    if (col >= safeWidth) {
-      lines.push("");
-      row += 1;
-      col = 0;
-    }
-    if (index === cursor) {
-      cursorRow = row;
-      cursorCol = col;
-    }
-    if (index === comment.length) break;
-    const char = comment[index];
-    if (char === "\n") {
-      lines.push("");
-      row += 1;
-      col = 0;
-      continue;
-    }
-    lines[row] += char;
-    col += 1;
+  for (let index = 0; index < targetRow; index += 1) next += Array.from(allLines[index] as string).length + 1;
+  // Land on the character whose cell column is closest to the current one.
+  let offset = 0;
+  let used = 0;
+  for (const char of allLines[targetRow] as string) {
+    const width = charWidth(char);
+    if (used + width > col) break;
+    used += width;
+    offset += 1;
   }
-  return { lines, cursorRow, cursorCol };
+  cursor = next + offset;
 }
 
 function writeAt(row: number, col: number, text: string): void {
@@ -103,7 +83,7 @@ function render(): void {
   const editorRows = Math.max(1, rows - selectionRows - 5);
   const wrappedSelection = wrapText(sanitizeTerminalText(pending.selectedText), innerWidth);
   const selected = wrappedSelection.slice(0, selectionRows);
-  const editing = commentLines(innerWidth);
+  const editing = layoutComment(comment, cursor, innerWidth);
   const editorStart = Math.max(0, editing.cursorRow - editorRows + 1);
   const visibleEditor = editing.lines.slice(editorStart, editorStart + editorRows);
 
@@ -119,7 +99,7 @@ function render(): void {
   visibleEditor.forEach((line, index) => writeAt(commentTitleRow + 1 + index, left, line));
 
   const footer = status || "Ctrl+S save  ·  Esc cancel  ·  Enter new line";
-  writeAt(rows, left, `\x1b[2m${Array.from(footer).slice(0, innerWidth).join("")}\x1b[0m`);
+  writeAt(rows, left, `\x1b[2m${truncateToWidth(footer, innerWidth)}\x1b[0m`);
 
   const visualCursorRow = editing.cursorRow - editorStart;
   if (visualCursorRow >= 0 && visualCursorRow < editorRows) {

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,4 +1,5 @@
 import type { Annotation } from "./types";
+import { charWidth } from "./width";
 
 /** Remove terminal control characters while retaining useful whitespace. */
 export function sanitizeTerminalText(text: string): string {
@@ -17,9 +18,19 @@ export function wrapText(text: string, width: number): string[] {
       output.push("");
       continue;
     }
-    for (let index = 0; index < chars.length; index += safeWidth) {
-      output.push(chars.slice(index, index + safeWidth).join(""));
+    let line = "";
+    let used = 0;
+    for (const char of chars) {
+      const width = charWidth(char);
+      if (used + width > safeWidth && line !== "") {
+        output.push(line);
+        line = "";
+        used = 0;
+      }
+      line += char;
+      used += width;
     }
+    output.push(line);
   }
   return output;
 }

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,0 +1,44 @@
+import { charWidth } from "./width";
+
+/**
+ * Lay the comment out in terminal cells and report where the cursor lands.
+ *
+ * The cursor column is measured in cells, not characters, so that wide
+ * characters do not push the reported position out of step with the screen.
+ */
+export function layoutComment(
+  comment: readonly string[],
+  cursor: number,
+  width: number,
+): { lines: string[]; cursorRow: number; cursorCol: number } {
+  const safeWidth = Math.max(1, width);
+  const lines: string[] = [""];
+  let row = 0;
+  let col = 0;
+  let cursorRow = 0;
+  let cursorCol = 0;
+  for (let index = 0; index <= comment.length; index += 1) {
+    const cells = index < comment.length ? charWidth(comment[index] as string) : 0;
+    // A wide character must not straddle the right edge.
+    if (col > 0 && col + cells > safeWidth) {
+      lines.push("");
+      row += 1;
+      col = 0;
+    }
+    if (index === cursor) {
+      cursorRow = row;
+      cursorCol = col;
+    }
+    if (index === comment.length) break;
+    const char = comment[index] as string;
+    if (char === "\n") {
+      lines.push("");
+      row += 1;
+      col = 0;
+      continue;
+    }
+    lines[row] += char;
+    col += cells;
+  }
+  return { lines, cursorRow, cursorCol };
+}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -4,6 +4,7 @@ import readline from "node:readline";
 import { copyAndArchiveAnnotations, restoreArchivedSet } from "./archive-workflow";
 import { writeClipboard } from "./clipboard";
 import { sanitizeTerminalText, wrapText } from "./format";
+import { stringWidth, truncateToWidth } from "./width";
 import { copyAnnotations } from "./manager-copy";
 import { stateDir } from "./paths";
 import {
@@ -72,9 +73,9 @@ function reloadArchives(): boolean {
 }
 
 function clipped(text: string, width: number): string {
-  const chars = Array.from(sanitizeTerminalText(text).replace(/\s+/g, " ").trim());
-  if (chars.length <= width) return chars.join("");
-  return `${chars.slice(0, Math.max(0, width - 1)).join("")}…`;
+  const value = sanitizeTerminalText(text).replace(/\s+/g, " ").trim();
+  if (stringWidth(value) <= width) return value;
+  return `${truncateToWidth(value, Math.max(0, width - 1))}…`;
 }
 
 function writeAt(row: number, col: number, text: string): void {

--- a/src/width.ts
+++ b/src/width.ts
@@ -1,0 +1,66 @@
+/**
+ * Terminal cell widths.
+ *
+ * East Asian wide and fullwidth characters occupy two terminal cells. Counting
+ * them as one shifts every column the editor computes, which misplaces the
+ * cursor and lets IME preedit overlays land inside existing text.
+ */
+
+const WIDE_RANGES: readonly (readonly [number, number])[] = [
+  [0x1100, 0x115f], // Hangul Jamo initial consonants
+  [0x2e80, 0x303e], // CJK radicals, Kangxi, CJK symbols and punctuation
+  [0x3041, 0x33ff], // Hiragana through CJK compatibility
+  [0x3400, 0x4dbf], // CJK unified ideographs extension A
+  [0x4e00, 0x9fff], // CJK unified ideographs
+  [0xa000, 0xa4cf], // Yi syllables
+  [0xa960, 0xa97f], // Hangul Jamo extended-A
+  [0xac00, 0xd7a3], // Hangul syllables
+  [0xf900, 0xfaff], // CJK compatibility ideographs
+  [0xfe10, 0xfe19], // Vertical forms
+  [0xfe30, 0xfe6f], // CJK compatibility forms, small form variants
+  [0xff00, 0xff60], // Fullwidth forms
+  [0xffe0, 0xffe6], // Fullwidth signs
+  [0x1f300, 0x1f64f], // Emoji
+  [0x1f900, 0x1f9ff], // Supplemental symbols and pictographs
+  [0x20000, 0x3fffd], // CJK extensions B and beyond
+];
+
+function isWide(codePoint: number): boolean {
+  for (const [start, end] of WIDE_RANGES) {
+    if (codePoint < start) return false;
+    if (codePoint <= end) return true;
+  }
+  return false;
+}
+
+/** Cells occupied by a single character. Control characters count as zero. */
+export function charWidth(char: string): number {
+  const codePoint = char.codePointAt(0);
+  if (codePoint === undefined) return 0;
+  if (codePoint < 0x20 || (codePoint >= 0x7f && codePoint < 0xa0)) return 0;
+  // Combining marks attach to the preceding character.
+  if (codePoint >= 0x0300 && codePoint <= 0x036f) return 0;
+  if (codePoint >= 0x200b && codePoint <= 0x200f) return 0;
+  return isWide(codePoint) ? 2 : 1;
+}
+
+/** Cells occupied by a string. */
+export function stringWidth(text: string): number {
+  let total = 0;
+  for (const char of text) total += charWidth(char);
+  return total;
+}
+
+/** Longest prefix of `text` that fits in `width` cells without splitting a character. */
+export function truncateToWidth(text: string, width: number): string {
+  if (width <= 0) return "";
+  let used = 0;
+  let output = "";
+  for (const char of text) {
+    const next = charWidth(char);
+    if (used + next > width) break;
+    output += char;
+    used += next;
+  }
+  return output;
+}

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -51,3 +51,17 @@ describe("formatAnnotations", () => {
     expect(output).toContain("````\n```example```\n````");
   });
 });
+
+describe("wrapText with wide characters", () => {
+  test("wraps on cells so lines fit the box", () => {
+    expect(wrapText("한글한글", 4)).toEqual(["한글", "한글"]);
+  });
+
+  test("never splits a wide character across lines", () => {
+    expect(wrapText("한글한", 5)).toEqual(["한글", "한"]);
+  });
+
+  test("mixes narrow and wide characters", () => {
+    expect(wrapText("a한b한", 4)).toEqual(["a한b", "한"]);
+  });
+});

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { layoutComment } from "../src/layout";
+
+const chars = (text: string): string[] => Array.from(text);
+
+describe("layoutComment", () => {
+  test("reports the cursor column in cells, not characters", () => {
+    const comment = chars("한글");
+    expect(layoutComment(comment, comment.length, 40).cursorCol).toBe(4);
+  });
+
+  test("counts narrow characters as one cell", () => {
+    const comment = chars("abc");
+    expect(layoutComment(comment, comment.length, 40).cursorCol).toBe(3);
+  });
+
+  test("mixes narrow and wide characters", () => {
+    const comment = chars("a한b");
+    expect(layoutComment(comment, comment.length, 40).cursorCol).toBe(4);
+    expect(layoutComment(comment, 2, 40).cursorCol).toBe(3);
+  });
+
+  test("never lets a wide character straddle the right edge", () => {
+    const comment = chars("한글한");
+    const result = layoutComment(comment, comment.length, 5);
+    expect(result.lines).toEqual(["한글", "한"]);
+    expect(result.cursorRow).toBe(1);
+    expect(result.cursorCol).toBe(2);
+  });
+
+  test("keeps explicit newlines", () => {
+    const comment = chars("한\n글");
+    const result = layoutComment(comment, comment.length, 40);
+    expect(result.lines).toEqual(["한", "글"]);
+    expect(result.cursorRow).toBe(1);
+    expect(result.cursorCol).toBe(2);
+  });
+});

--- a/test/width.test.ts
+++ b/test/width.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { charWidth, stringWidth, truncateToWidth } from "../src/width";
+
+describe("charWidth", () => {
+  test("gives Hangul syllables two cells", () => {
+    expect(charWidth("한")).toBe(2);
+    expect(charWidth("ㄱ")).toBe(2);
+  });
+
+  test("gives CJK and fullwidth forms two cells", () => {
+    expect(charWidth("漢")).toBe(2);
+    expect(charWidth("あ")).toBe(2);
+    expect(charWidth("Ａ")).toBe(2);
+  });
+
+  test("gives Latin and punctuation one cell", () => {
+    expect(charWidth("a")).toBe(1);
+    expect(charWidth("·")).toBe(1);
+  });
+
+  test("gives control characters no cells", () => {
+    expect(charWidth("\u0007")).toBe(0);
+  });
+});
+
+describe("stringWidth", () => {
+  test("adds the cells of each character", () => {
+    expect(stringWidth("한글abc")).toBe(7);
+    expect(stringWidth("")).toBe(0);
+  });
+});
+
+describe("truncateToWidth", () => {
+  test("never splits a wide character", () => {
+    expect(truncateToWidth("한글", 3)).toBe("한");
+    expect(truncateToWidth("한글", 4)).toBe("한글");
+  });
+
+  test("returns nothing when no cells are available", () => {
+    expect(truncateToWidth("한", 0)).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

Typing Korean (or any East Asian text) into the annotation editor puts the cursor in the wrong place, and the character being composed appears to duplicate itself inside the text that is already there.

Both symptoms come from one line. `commentLines()` in `src/editor.ts` advances the column by one for every character:

```ts
lines[row] += char;
col += 1;
```

East Asian characters occupy two terminal cells. After typing five Hangul syllables the text is ten cells wide, but the editor reports column five and places the cursor there with `\x1b[{row};{col}H`. The cursor sits in the middle of the text.

The apparent duplication is the same bug seen through the IME. While a syllable is being composed the terminal paints the preedit overlay at the cursor position the application reported, which is mid-text, so the composing syllable shows up inside what was already typed. On commit the application redraws and the syllable jumps to the end.

## Fix

Add `src/width.ts`, which reports how many cells a character occupies: two for Hangul syllables and jamo, CJK ideographs, kana, fullwidth forms, and emoji, one for the rest, zero for control characters and combining marks.

Measure every column in cells rather than characters:

- `src/layout.ts` (extracted from `editor.ts`) computes the cursor row and column in cells, and wraps a line before a wide character would straddle the right edge.
- `wrapText()` in `src/format.ts` wraps on cells, so Korean selections no longer overflow the box.
- The editor footer and the manager's list entries clip on cells.
- Vertical cursor motion keeps the visual column through mixed-width text.

`commentLines()` moved into its own module because `editor.ts` starts the TUI as an import side effect, which leaves the geometry untestable where it was.

## Tests

15 new tests covering cell widths, comment layout, and wrapping. The full suite is 53 tests, all passing, and `bun run typecheck` is clean.

```
bun test    53 pass, 0 fail
```

Reported and reproduced on macOS with a Korean IME.
