### PR TITLE
assets: install cards in the Herdr Annotate palette

### DIFF
--- a/assets/install-full.svg
+++ b/assets/install-full.svg
@@ -1,14 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="220" height="120" viewBox="0 0 220 120" role="img" aria-labelledby="t">
   <title id="t">Full install: terminal annotations plus document and agent-reply review</title>
-  <g id="ground"><rect width="220" height="120" fill="#000000"/></g>
-  <g id="marks" fill="none" stroke-width="2.5" stroke-linecap="square">
-    <path d="M18 34 V22 H30" stroke="#ac74ec"/>
-    <path d="M18 66 V78 H62" stroke="#2ce068"/>
-    <path d="M92 78 H132 M112 78 V72" stroke="#4498e0"/>
-    <path d="M202 66 V78 H190" stroke="#f2d24a"/>
+  <defs>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#f7ca5e"/><stop offset="1" stop-color="#ec9d3f"/></linearGradient>
+  </defs>
+  <g id="card"><rect x="1.5" y="1.5" width="217" height="117" rx="12" fill="#171429" stroke="#312b52" stroke-width="3"/></g>
+  <g id="type" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Arial, sans-serif">
+    <text x="20" y="56" font-size="36" font-weight="800" font-style="italic" letter-spacing="-0.8" fill="url(#gold)">Full</text>
+    <text x="20" y="98" font-size="12" font-weight="600" fill="#c9c6f1">annotate + review documents</text>
   </g>
-  <g id="type" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" fill="#f2f2f2">
-    <text x="36" y="63" font-size="30" font-weight="700" letter-spacing="-0.5">Full</text>
-    <text x="18" y="102" font-size="11.5" fill="#a3a3a3">annotations + document review</text>
+  <g id="marks" fill="none" stroke-linecap="round">
+    <path d="M22 66c24-3 50-3 76 0" stroke="#e0403a" stroke-width="2.5"/>
+    <g stroke="#c9c6f1" stroke-width="1.8" stroke-linejoin="round">
+      <rect x="148" y="30" width="46" height="26" rx="5"/>
+      <path d="M156 40h30M156 47h18"/>
+      <path d="M160 56l-4 7 11-7"/>
+    </g>
+    <path d="M176 47c2-2 4-2 6 0s4 2 6 0" stroke="#e0403a" stroke-width="1.6"/>
   </g>
 </svg>

--- a/assets/install-lite.svg
+++ b/assets/install-lite.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="220" height="120" viewBox="0 0 220 120" role="img" aria-labelledby="t">
   <title id="t">Lite install: terminal annotations only</title>
-  <g id="ground"><rect width="220" height="120" fill="#000000"/></g>
-  <g id="marks" fill="none" stroke-width="2.5" stroke-linecap="square">
-    <path d="M18 66 V78 H62" stroke="#2ce068"/>
+  <g id="card"><rect x="1.5" y="1.5" width="217" height="117" rx="12" fill="#171429" stroke="#312b52" stroke-width="3"/></g>
+  <g id="type" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Arial, sans-serif">
+    <text x="20" y="56" font-size="36" font-weight="800" font-style="italic" letter-spacing="-0.8" fill="#c9c6f1">Lite</text>
+    <text x="20" y="98" font-size="12" font-weight="600" fill="#c9c6f1">annotate terminal text</text>
   </g>
-  <g id="type" font-family="'Segoe UI', system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" fill="#f2f2f2">
-    <text x="36" y="63" font-size="30" font-weight="700" letter-spacing="-0.5">Lite</text>
-    <text x="18" y="102" font-size="11.5" fill="#a3a3a3">annotations only</text>
+  <g id="marks" fill="none" stroke-linecap="round">
+    <path d="M22 66c24-3 50-3 76 0" stroke="#e0403a" stroke-width="2.5"/>
   </g>
 </svg>


### PR DESCRIPTION
Full/Lite install cards redrawn with the palette sampled from the Herdr Annotate logo (same values as the announcement banner): #171429 ground, #312b52 border, #c9c6f1 lavender, #f7ca5e→#ec9d3f gold, #e0403a annotation red; heavy italic title like the wordmark.