### PR TITLE
capture: take a handed-off selection file before the clipboard (headless servers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ herdr --remote <host> --remote-keybindings server
 Without the flag, `herdr --remote` uses your local keys and drops plugin bindings, so the
 key does nothing.
 
+Known Herdr limitation ([herdrdev/herdr#3380](https://github.com/herdrdev/herdr/issues/3380)): the
+prefix keypress clears a retained mouse selection, and a copy-mode selection is cancelled
+before the action runs, so `selected_text` never reaches the plugin and it falls back to the
+server's clipboard, which a headless server does not have. Until that is fixed, use the
+Neovim mapping below on headless servers: it hands the selection over in a file.
+
 ## Selection limits
 
 Herdr Annotate reads text that Herdr copies to the system clipboard. The plugin cannot read selection state from Neovim or another terminal application.
@@ -198,17 +204,18 @@ Add this visual-mode mapping to `~/.config/nvim/lua/config/keymaps.lua` for Lazy
 
 ```lua
 vim.keymap.set("x", "<leader>a", function()
-  vim.cmd('normal! "+y')
-  vim.fn.jobstart({
-    "herdr",
-    "plugin",
-    "action",
-    "invoke",
-    "annotate.capture",
-  })
+  -- Hand the selection to the plugin through a file: works on headless servers too.
+  vim.cmd('normal! "zy')
+  local base = os.getenv("XDG_RUNTIME_DIR")
+  if not base or base == "" then base = vim.fn.fnamemodify(vim.fn.tempname(), ":h") end
+  local dir = base .. "/herdr-annotate-" .. vim.loop.getuid()
+  vim.fn.mkdir(dir, "p", "0700")
+  vim.fn.writefile(vim.split(vim.fn.getreg("z"), "\n"), dir .. "/selection")
+  vim.fn.jobstart({ "herdr", "plugin", "action", "invoke", "annotate.capture" })
 end, { desc = "Annotate in Herdr" })
 ```
 
 Select text with the mouse or Visual mode. Then press `<leader>a` to open Herdr Annotate.
+The file is read once and removed; a file older than 15 seconds is ignored.
 
 LazyVim uses `Space` as `<leader>` by default. The mapping keeps mouse support and leaves normal Neovim commands unchanged.

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -24,6 +24,12 @@ try {
   if (!root) throw new Error("HERDR_PLUGIN_ROOT is not set");
 
   if (!selectedText) {
+    // A program on the server (Neovim's mapping) may have handed the selection over in a
+    // file; that beats the clipboard, which a headless server does not have.
+    const { takeHandoff } = await import("./handoff");
+    selectedText = takeHandoff();
+  }
+  if (!selectedText) {
     const { readClipboard } = await import("./clipboard");
     const clipboard = readClipboard();
     if (!clipboard.ok) throw new Error(clipboard.message);

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * A selection handed to `annotate.capture` by another program on the same machine as the
+ * Herdr server (Neovim, a script), for hosts where the plugin cannot read a clipboard:
+ * headless servers reached over SSH or `herdr --remote`.
+ *
+ * The writer puts the text in {@link handoffPath} and invokes the action; the action takes
+ * the file (reads and deletes it) when it is fresh. Anything older is a leftover, not a
+ * selection, and is ignored so a stale file can never be annotated by surprise.
+ */
+export const HANDOFF_MAX_AGE_MS = 15_000;
+
+/** `$XDG_RUNTIME_DIR` (per user, tmpfs) when set, else the system temp dir, plus the uid. */
+export function handoffPath(env: NodeJS.ProcessEnv = process.env): string {
+  const base = env.XDG_RUNTIME_DIR?.trim() || os.tmpdir();
+  const uid = typeof process.getuid === "function" ? String(process.getuid()) : "user";
+  return path.join(base, `herdr-annotate-${uid}`, "selection");
+}
+
+/** The handed-off text when the file exists and is fresh; the file is removed either way. */
+export function takeHandoff(
+  file: string = handoffPath(),
+  now: number = Date.now(),
+  maxAgeMs: number = HANDOFF_MAX_AGE_MS,
+): string | undefined {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(file);
+  } catch {
+    return undefined;
+  }
+  let text: string | undefined;
+  if (stat.isFile() && now - stat.mtimeMs <= maxAgeMs) {
+    try {
+      text = fs.readFileSync(file, "utf8");
+    } catch {
+      text = undefined;
+    }
+  }
+  fs.rmSync(file, { force: true });
+  return text && text.trim() ? text : undefined;
+}

--- a/test/handoff.test.ts
+++ b/test/handoff.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { HANDOFF_MAX_AGE_MS, handoffPath, takeHandoff } from "../src/handoff";
+
+function tempFile(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "herdr-annotate-handoff-"));
+  return path.join(dir, "selection");
+}
+
+describe("handoffPath", () => {
+  test("prefers XDG_RUNTIME_DIR and is per user", () => {
+    const p = handoffPath({ XDG_RUNTIME_DIR: "/run/user/1000" });
+    expect(p.startsWith(path.join("/run/user/1000", "herdr-annotate-"))).toBe(true);
+    expect(path.basename(p)).toBe("selection");
+  });
+  test("falls back to the temp dir", () => {
+    expect(handoffPath({}).startsWith(os.tmpdir())).toBe(true);
+  });
+});
+
+describe("takeHandoff", () => {
+  test("returns a fresh file's text and removes it", () => {
+    const file = tempFile();
+    fs.writeFileSync(file, "hello\nworld\n");
+    expect(takeHandoff(file)).toBe("hello\nworld\n");
+    expect(fs.existsSync(file)).toBe(false);
+  });
+  test("ignores and removes a stale file", () => {
+    const file = tempFile();
+    fs.writeFileSync(file, "old");
+    const later = Date.now() + HANDOFF_MAX_AGE_MS + 1000;
+    expect(takeHandoff(file, later)).toBeUndefined();
+    expect(fs.existsSync(file)).toBe(false);
+  });
+  test("ignores blank text and a missing file", () => {
+    const file = tempFile();
+    fs.writeFileSync(file, "  \n");
+    expect(takeHandoff(file)).toBeUndefined();
+    expect(takeHandoff(file)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
For #23. The selection paths through Herdr's keybindings are a Herdr bug (herdrdev/herdr#3380: the prefix keypress clears a retained selection and copy-mode is cancelled before the action runs). This PR makes the Neovim path work on headless servers now: the mapping writes the selection to `$XDG_RUNTIME_DIR/herdr-annotate-<uid>/selection` and `annotate.capture` takes that file (fresh, once) before falling back to the clipboard. Lite and Full both share `src/`, so both get it.

Tests: `bun test` 58 pass; `bun run typecheck` clean.

refs #23

https://claude.ai/code/session_01L232F8ev8RX6Jwd7PepsUz