### PR TITLE
Fix plannotator-tui fetch for native Windows (Git Bash/MSYS/Cygwin)

### DIFF
--- a/scripts/fetch-plannotator-tui.sh
+++ b/scripts/fetch-plannotator-tui.sh
@@ -36,15 +36,17 @@ if [ -n "${PLANNOTATOR_TUI_BIN:-}" ]; then
   exit 0
 fi
 
+windows_ext=""
 case "$(uname -s)/$(uname -m)" in
   Darwin/arm64)            target=aarch64-apple-darwin ;;
   Darwin/x86_64)           target=x86_64-apple-darwin ;;
   Linux/x86_64)            target=x86_64-unknown-linux-gnu ;;
   Linux/aarch64|Linux/arm64) target=aarch64-unknown-linux-gnu ;;
+  MINGW64*/x86_64|MSYS_NT*/x86_64|CYGWIN*/x86_64) target=x86_64-pc-windows-msvc; windows_ext=".exe" ;;
   *) echo "warning: no plannotator-tui build for $(uname -s)/$(uname -m); the review pane is unavailable" >&2; exit 0 ;;
 esac
 
-asset="plannotator-tui-$target"
+asset="plannotator-tui-$target$windows_ext"
 base="https://github.com/plannotator/plannotator-tui/releases/download/v$version"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
## Problem

The README documents native Windows as a supported platform ("macOS, Linux, or Windows... On Windows, native Herdr plugin support is preview/best-effort"), and `plannotator-tui` releases already publish an `x86_64-pc-windows-msvc.exe` asset. However `scripts/fetch-plannotator-tui.sh`'s `uname`-based case statement only matches `Darwin` and `Linux`:

```sh
case "$(uname -s)/$(uname -m)" in
  Darwin/arm64)            target=aarch64-apple-darwin ;;
  Darwin/x86_64)           target=x86_64-apple-darwin ;;
  Linux/x86_64)            target=x86_64-unknown-linux-gnu ;;
  Linux/aarch64|Linux/arm64) target=aarch64-unknown-linux-gnu ;;
  *) echo "warning: no plannotator-tui build for $(uname -s)/$(uname -m); the review pane is unavailable" >&2; exit 0 ;;
esac
```

On native Windows, Herdr's plugin build step runs this script under Git Bash/MSYS, where `uname -s` reports `MINGW64_NT-...` (not `Darwin`/`Linux`). It falls through to the default branch, prints a warning, and exits 0 without downloading — silently leaving the document-review pane (`annotate.open` / `annotate.last`) unavailable, even though a matching release binary exists.

## Fix

Add a case for `MINGW64*`/`MSYS_NT*`/`CYGWIN*` on `x86_64` that selects the `x86_64-pc-windows-msvc` target and appends `.exe` when fetching/verifying the asset. The existing sha256 verification against `SHA256SUMS` is unchanged and reused as-is.

## Verification

On Windows (Git Bash), with a clean `bin/`:

```
$ bash scripts/fetch-plannotator-tui.sh
downloading https://github.com/plannotator/plannotator-tui/releases/download/v0.3.1/plannotator-tui-x86_64-pc-windows-msvc.exe
installed plannotator-tui 0.3.1 (x86_64-pc-windows-msvc)

$ bin/plannotator-tui --version
plannotator-tui 0.3.1

$ bash scripts/plannotator-tui.sh --version
plannotator-tui 0.3.1
```

Also confirmed `herdr plugin install plannotator/herdr-annotate --yes` picks this branch up correctly and the `annotate.open`/`annotate.last` review pane actions work end-to-end on Windows afterward.